### PR TITLE
Export go_eol function and create a command for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ This means you can use functions which are available in the `math` module.
 Lists them using `:lua print(vim.inspect(math))`. 
 All the math module functions are put in global namespace when quickmath is initiated. So instead of writing `math.cos`, `cos` can be simply written.
 
+**Get that output**
+
+You can select the output by pressing `$` when at the end of the line, or `$$` anywhere else in the line.
+Then just `y`ank.
+
+
 Note
 ----
 

--- a/lua/quickmath/init.lua
+++ b/lua/quickmath/init.lua
@@ -70,7 +70,7 @@ local function StartSession()
 	vim.api.nvim_command("set ft=lua")
 
   vim.cmd [[set buftype=nowrite]]
-  vim.api.nvim_buf_set_keymap(0, "n", "$", ":QMSelectOutput<CR>", { silent=true })
+  vim.api.nvim_buf_set_keymap(0, "n", "$", [[:lua require"quickmath".go_eol()<CR>]], { silent=true })
 
 end
 
@@ -118,6 +118,7 @@ end
 
 return {
 StartSession = StartSession,
+
 go_eol = go_eol,
 
 }

--- a/lua/quickmath/init.lua
+++ b/lua/quickmath/init.lua
@@ -70,7 +70,7 @@ local function StartSession()
 	vim.api.nvim_command("set ft=lua")
 
   vim.cmd [[set buftype=nowrite]]
-  vim.api.nvim_buf_set_keymap(0, "n", "$", "", { silent=true, callback=go_eol })
+  vim.api.nvim_buf_set_keymap(0, "n", "$", ":QMSelectOutput<CR>", { silent=true })
 
 end
 
@@ -118,6 +118,7 @@ end
 
 return {
 StartSession = StartSession,
+go_eol = go_eol,
 
 }
 

--- a/plugin/quickmath.lua
+++ b/plugin/quickmath.lua
@@ -1,2 +1,3 @@
 -- to have a clean 100% lua statistics in Github ;) I know it's perfectionism
 vim.cmd [[command! Quickmath lua require("quickmath").StartSession()]]
+vim.cmd [[command! QMSelectOutput lua require("quickmath").go_eol()]]

--- a/plugin/quickmath.lua
+++ b/plugin/quickmath.lua
@@ -1,3 +1,2 @@
 -- to have a clean 100% lua statistics in Github ;) I know it's perfectionism
 vim.cmd [[command! Quickmath lua require("quickmath").StartSession()]]
-vim.cmd [[command! QMSelectOutput lua require("quickmath").go_eol()]]

--- a/src/select_virtual.lua.t
+++ b/src/select_virtual.lua.t
@@ -1,6 +1,6 @@
 ##quickmath
 @bind_select_virtual_keymap+=
-vim.api.nvim_buf_set_keymap(0, "n", "$", "", { silent=true, callback=go_eol })
+vim.api.nvim_buf_set_keymap(0, "n", "$", [[:lua require"quickmath".go_eol()<CR>]], { silent=true })
 
 @declare_functions+=
 local go_eol
@@ -11,6 +11,9 @@ function go_eol()
   @if_not_go_eol
   @else_highlight_virtual_text_and_wait
 end
+
+@export_symbols+=
+go_eol = go_eol,
 
 @if_not_go_eol+=
 if not eol then


### PR DESCRIPTION
I got a chance to test #1, but got this error
```
5108: Error executing lua .../nvim/site/plugins/quickmath.nvim/lua/quickmath/init.lua:73: invalid key: callback  
stack traceback:  
        [C]: in function 'nvim_buf_set_keymap'  
        .../nvim/site/plugins/quickmath.nvim/lua/quickmath/init.lua:73: in function 'StartSession'  
        [string ":lua"]:1: in main chunk
```
So using your commits as a tutorial, and exported(tried not to) `go_eol`, so i could make the `:QMSelectOutput` command and map that instead, using the `{rhs}` arg of `nvim_buf_set_keymap`.

This seems to work for me. And i guess it allows the user to bind their own keys to the function.